### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/tests/spline_test.rs
+++ b/tests/spline_test.rs
@@ -40,7 +40,7 @@ static FO_POINTS_6581: [(i32, i32); 31] = [
 
 fn set_f0(f0: &mut [i32; 2048]) {
     let points = FO_POINTS_6581
-        .into_iter()
+        .iter()
         .map(|&pt| spline::Point {
             x: pt.0 as f64,
             y: pt.1 as f64,


### PR DESCRIPTION
`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.