### PR TITLE
Only run vector benchmarks on appropriate targets

### DIFF
--- a/benches/sampler_bench.rs
+++ b/benches/sampler_bench.rs
@@ -10,12 +10,16 @@ pub fn bench_compute_convolution_fir(c: &mut Criterion) {
         let fir = [5i16; 1024];
         b.iter(|| sampler.compute_convolution_fir(&samples[..], &fir[..]))
     });
+    #[target_feature(enable = "avx2")]
+    #[cfg(all(feature = "std", any(target_arch = "x86", target_arch = "x86_64")))]
     c.bench_function("convolution_fir_avx2", |b| {
         let sampler = Sampler::new(Synth::new(ChipModel::Mos6581));
         let samples = [2i16; 1024];
         let fir = [5i16; 1024];
         b.iter(|| unsafe { sampler.compute_convolution_fir_avx2(&samples[..], &fir[..]) })
     });
+    #[target_feature(enable = "sse4.2")]
+    #[cfg(all(feature = "std", any(target_arch = "x86", target_arch = "x86_64")))]
     c.bench_function("convolution_fir_sse", |b| {
         let sampler = Sampler::new(Synth::new(ChipModel::Mos6581));
         let samples = [2i16; 1024];


### PR DESCRIPTION
Running benchmarks was failing on an ARM target because compute_convolution_fir_avx2 and compute_convolution_fir_sse were not defined. I've config copied the guards from `src/sampler.rs` to the benchmark code.